### PR TITLE
Fixed cluster role to enable POST requests

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -33,10 +33,18 @@ rules:
   - ""
   resources:
   - services
-  - services/proxy
   verbs:
   - get
   - list
+  - proxy
+- apiGroups:
+  - ""
+  resources:
+  - services/proxy
+  verbs:
+  - get
+  # the 'create' verb is required because otherwise POST requests are blocked
+  - create
   - proxy
 - apiGroups:
   - ""


### PR DESCRIPTION
The Kubernetes API will block POST requests to the function service proxy because it wrongly assumes that the proxy object is going to be created. Tested with Kubernetes v1.11.2.